### PR TITLE
Set base url to v1.1

### DIFF
--- a/circleci/config.go
+++ b/circleci/config.go
@@ -1,6 +1,8 @@
 package circleci
 
 import (
+	"net/url"
+
 	"github.com/jszwedko/go-circleci"
 )
 
@@ -18,7 +20,7 @@ func (c *Config) Client() (interface{}, error) {
 	var org Organization
 
 	org.name = c.Organization
-	org.client = &circleci.Client{Token: c.Token}
+	org.client = &circleci.Client{Token: c.Token, BaseURL: &url.URL{Host: "circleci.com", Scheme: "https", Path: "/api/v1.1/"}}
 
 	return &org, nil
 }


### PR DESCRIPTION
CircleCI has changed the base URL. For some reason the maintainer of the circleci golang library does not want to update it, so I hardcoded the correct one directly in a plugin.